### PR TITLE
fix #119: Revert default provider in case not set in env

### DIFF
--- a/src/lib/llm-provider.ts
+++ b/src/lib/llm-provider.ts
@@ -26,7 +26,7 @@ const llmConfigurations: Record<LLMProviderType, LLMConfiguration> = {
 
 export function llmProviderSetup() {
   const providerType = process.env.LLM_PROVIDER as LLMProviderType;
-  const configuration = llmConfigurations[providerType ?? "openai"];
+  const configuration = llmConfigurations[providerType || "openai"];
 
   if (!configuration) {
     const supportedProviders = Object.values(LLMProviderType).join(", ");

--- a/src/lib/llm-provider.ts
+++ b/src/lib/llm-provider.ts
@@ -26,7 +26,7 @@ const llmConfigurations: Record<LLMProviderType, LLMConfiguration> = {
 
 export function llmProviderSetup() {
   const providerType = process.env.LLM_PROVIDER as LLMProviderType;
-  const configuration = llmConfigurations[providerType];
+  const configuration = llmConfigurations[providerType ?? "openai"];
 
   if (!configuration) {
     const supportedProviders = Object.values(LLMProviderType).join(", ");


### PR DESCRIPTION
## Problem

After PR #115 an error was occurring:
```
Error: Unsupported LLM provider: "undefined". Supported providers are: openai, ollama
at llmProviderSetup (webpack-internal:///(rsc)/./src/lib/llm-provider.ts:35:15)
at POST (webpack-internal:///(rsc)/./src/app/api/chat/route.ts:156:87)
```

Because it was missing the default for the case when the provider wasn't set in `.env.local`

## Solution
Revert the default to be using `"openai"` if the `LLM_PROVIDER` environment variable isn't set.